### PR TITLE
Require serverpacks mod

### DIFF
--- a/TabardMod.properties
+++ b/TabardMod.properties
@@ -1,6 +1,7 @@
 classname				= org.jubaroo.wurmunlimited.mods.tabards.Initiator
 classpath				= TabardMod.jar
 serverPacks				= !TabardPack.jar
+depend.requires			= serverpacks
 sharedClassLoader		= true
 
 #Jenn_Kellon


### PR DESCRIPTION
I had a request from a user today. He was missing the serverpacks mod and had to fiddle with adding the serverpacks.properties. With the dependency mechanism the serverpacks mod can be loaded automaticly without any required user action.